### PR TITLE
Updates for changes to opendrift and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,20 @@ Manager for particle tracking simulations.
 <p><small>Project based on the <a target="_blank" href="https://github.com/jbusecke/cookiecutter-science-project">cookiecutter science project template</a>.</small></p>
 
 
+# Installation
+
+Install with
+
+    pip install particle-tracking-manager
+
+or
+
+    conda install -c conda-forge particle-tracking-manager
+
+To install environment from github repo after cloning repo:
+
+    conda env create -f environment.yml
+
 To install packages to run pre-commit:
 
     mamba install --file requirements-dev.txt

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   # Examples (remove and add as needed)
   - adios_db
   - aiohttp
+  - fastparquet
   - jupyter
   - jupyterlab
   - xarray

--- a/particle_tracking_manager/cli.py
+++ b/particle_tracking_manager/cli.py
@@ -47,6 +47,17 @@ def is_datestr(s):
         return False
 
 
+def is_deltastr(s):
+    """Check if string is actually a Timedelta."""
+
+    try:
+        out = pd.Timedelta(s)
+        assert not pd.isnull(out)
+        return True
+    except (ValueError, AssertionError):
+        return False
+
+
 # https://sumit-ghosh.com/articles/parsing-dictionary-key-value-pairs-kwargs-argparse-python/
 class ParseKwargs(argparse.Action):
     """With can user can input dicts on CLI."""
@@ -70,6 +81,8 @@ class ParseKwargs(argparse.Action):
                 value = None
             elif is_datestr(value):
                 value = pd.Timestamp(value)
+            elif is_deltastr(value):
+                value = pd.Timedelta(value)
             getattr(namespace, self.dest)[key] = value
 
 

--- a/particle_tracking_manager/the_manager_config.json
+++ b/particle_tracking_manager/the_manager_config.json
@@ -124,6 +124,12 @@
         "ptm_level": 1,
         "description": "Name of ocean model to use for driving drifter simulation, by default None. Use None for testing and set up. Otherwise input a string. Options are \"NWGOA\", \"CIOFS\", \"CIOFS_now\". Alternatively keep as None and set up a separate reader (see example in docs)."
     },
+    "ocean_model_local": {
+        "type": "bool",
+        "default": false,
+        "ptm_level": 3,
+        "description": "Set to True to use local version of known `ocean_model` instead of remote version."
+    },
     "surface_only": {
         "type": "bool",
         "default": "None",


### PR DESCRIPTION
* updated to using version of `opendrift` in which you can input an xarray Dataset directly
* added new parameter for built-in ocean_models to specify whether to look locally or remote for the output (`ocean_model_local`)
* added local model output information for known models using parquet files for kerchunk access to model output
* changed `max_speed` parameter, which controls buffer size in `opendrift`, to 2 from 5.
* improved handling of "steps", "duration", and "end_time" parameters.
* improved reader interaction and speed with `opendrift` by dropping unnecessary variables from ocean_model Dataset, separating out the `standard_name` mapping input to the ROMS reader in `opendrift`, added option for whether or not to use wet/dry masks in ocean_model output if available