### PR TITLE
Pin numpy version to <2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - jupyterlab
   - kerchunk
   - xarray
-  - numpy
+  - numpy<2
   - opendrift
   - scipy
   - dask


### PR DESCRIPTION
### Summary
This MR pins the required numpy version to v1. This fixes errors caused by breaking changes in numpy v2.