### PR TITLE
no longer deleting the "*_initial.nc" file

### DIFF
--- a/particle_tracking_manager/models/opendrift/opendrift.py
+++ b/particle_tracking_manager/models/opendrift/opendrift.py
@@ -1051,12 +1051,13 @@ class OpenDriftModel(ParticleTrackingManager):
         self.o.outfile_name = self.output_file
         self.output_file = self.output_file
 
-        try:
-            # remove initial file to save space
-            os.remove(self.output_file_initial)
-        except PermissionError:
-            # windows issue
-            pass
+        # don't remove the initial netcdf file since will use that for plots if needed
+        # try:
+        #     # remove initial file to save space
+        #     os.remove(self.output_file_initial)
+        # except PermissionError:
+        #     # windows issue
+        #     pass
 
     @property
     def _config(self):


### PR DESCRIPTION
that way it can be used for plotting if the final output is parquet.

Every simulation now keeps the initial netcdf file "*_initial.nc", which only have OpenDrift metadata in it, and which can be used to create plots from. This is necessary if you output in parquet, which is currently created from the netcdf file. Converting the parquet file to netcdf didn't work correctly and didn't seem to keep necessary attributes, though I didn't try too hard since this file was already available. In the updated version of PTM, there isn't an "extra" _initial file available so we will have to choose a new solution at that point.